### PR TITLE
Update the security group in Creation of DB

### DIFF
--- a/workshop/content/database-migration/Create-target-DB.en.md
+++ b/workshop/content/database-migration/Create-target-DB.en.md
@@ -73,15 +73,10 @@ For production workloads, we recommend enabling the standby instance to enable <
 4. In the **Connectivity** section:
 
     * In **Virtual Private Cloud (VPC)**, select **TargetVPC** (this is the <a href="https://aws.amazon.com/vpc/" target="_blank" rel="noopener noreferrer">Amazon Virtual Private Cloud</a> that was automatically created for this lab)
-    * In **Additional connectivity configuration -> VPC Security Group**, select **Create new** VPC security group and give it a name (e.g. "DB-SG").
+    * In **Additional connectivity configuration -> VPC Security Group**, select **Existing VPC Security Groups** (use "DB-SG").
     * Note that the DB Subnet group you have created earlier will be automatically selected
 
     ![6_db](/db-mig/6_db.png)
-
-
-    {{% notice note %}}
-Note: You will edit the DB-SG VPC security group later to make sure that the DMS Replication Instance is able to access the target database and to allow access from your Webserver.
-{{% /notice %}}
 
 5. For the **Database authentication**, choose **Password authentication**.
 


### PR DESCRIPTION
In the Set up Networking step we asked customer to create a security group with the name DB-SG. That Security group has an inbound rule to allow the connectivity with the target database from Replica instance. In this step we are asking the customer to create again the Security Group and giving them the example name as it was the one created in the previous step. Also, we say to the customer that we will modify the security group later. The /db-mig/6_db.png shows a screenshot with "Existing security group" selected and not created. That is the reason of my suggestion of this to be addressed, to have consistency between text, image and previous steps. Thanks

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
